### PR TITLE
Removed Bearer from API Key

### DIFF
--- a/mediumroast_py/api/mr_server.py
+++ b/mediumroast_py/api/mr_server.py
@@ -19,7 +19,7 @@ class Auth:
             "user": self.USER,
             "secret": self.SECRET,
             "rest_server": self.REST_SERVER,
-            "api_key": self.API_KEY
+            "api_key": 'Bearer ' + self.API_KEY
         }
 
     def logout(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mediumroast_py"
-version = "0.3.32"
+version = "0.3.33"
 description = "A package to perform ETL (Extract, Transform and Load) and  interact with the mediumroast.io application."
 authors = ["Michael Hay <michael.hay@mediumroast.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Changed how to handle API keys such that we do not have to put the string `Bearer` in a configuration file.